### PR TITLE
Adding QuillCTF and EKO CTF to the CTF List

### DIFF
--- a/Check This Out/README.md
+++ b/Check This Out/README.md
@@ -35,6 +35,12 @@ Check This Out
 
 - [EtherHack](https://etherhack.positive.com/#/) 
 
+- [QuillCTF](https://bit.ly/QuillCTF) 
+
+- [EKO Blockchain CTF](https://www.ctfprotocol.com/tracks/eko2022) 
+
+
+
 # Cryptographic CTFs
 
 - [CryptoHack](https://cryptohack.org/)


### PR DESCRIPTION
Adding QuillCTF and EKO CTF to the CTF List

Here are details of both CTFs:
QuillCTF: https://bit.ly/QuillCTF
EKO CTF: https://www.ctfprotocol.com/tracks/eko2022
